### PR TITLE
Replace UB copy_nonoverlapping to `addr_of!(arr)` with a simple loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HEAD
 
+# 0.8.3
+
+Fix:
+- Soundness issue: "writing to addr_of!(arr) is UB" ([#2](https://github.com/Qqwy/rust-overloaded_literals/issues/2)), thank you, @RalfJung!
+
 Doc:
 - Fixed a typo in the documentation (PR [#1](https://github.com/Qqwy/rust-overloaded_literals/pull/1), thank you, @vortexofdoom!)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "2b62c6d3ea43cbe0bc5a081f276fd477e4291d168aacc9f9d98073325333c0d4"
 
 [[package]]
 name = "overloaded_literals"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "const-str",
  "overloaded_literals_macro",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "overloaded_literals_macro"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "quote",
  "syn",

--- a/overloaded_literals/Cargo.toml
+++ b/overloaded_literals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overloaded_literals"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 
 description = "Overloaded Literals to construct your datatypes without boilerplate and with compile-time validation"
@@ -15,7 +15,7 @@ categories = ["development-tools", "rust-patterns", "no-std", "no-std::no-alloc"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-overloaded_literals_macro = { version = "= 0.8.2", path = "../overloaded_literals_macro" }
+overloaded_literals_macro = { version = "= 0.8.3", path = "../overloaded_literals_macro" }
 tlist = "0.7.0"
 
 [dev-dependencies]

--- a/overloaded_literals_macro/Cargo.toml
+++ b/overloaded_literals_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overloaded_literals_macro"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 
 description = "Internal proc-macro implementation crate for the overloaded_literals crate."


### PR DESCRIPTION
Fixes #2

Thank you very much for reporting, @RalfJung !

Besides fixing the soundness problem, the 'writing to array elems in a loop' implementation is also much easier to reason about. It feels great to be able to remove the original implementation which pretty much required a long prose explanation of what is what accomplishing, and the new implementation needs no `unsafe` anymore!

🥳 